### PR TITLE
Fix view navigator and add grid dimension feature

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ import bpy
 # Import all the modules that contain your classes
 from . import properties
 from .operators import view_navigator, op_3d, sketch_tools, reference_manager
-from .ui import panel
+from .ui import panel, draw_handlers
 
 # A list of all modules that have their own register() functions
 modules = [
@@ -28,6 +28,7 @@ modules = [
     sketch_tools,
     reference_manager,
     panel,
+    draw_handlers,
 ]
 
 def register():

--- a/operators/view_navigator.py
+++ b/operators/view_navigator.py
@@ -28,8 +28,9 @@ class VIEW_OT_set_view_axis(bpy.types.Operator):
             if self.view_type == 'PERSP':
                 bpy.ops.view3d.view_perspective()
             else:
-                if area.spaces.active.region_3d.view_perspective != 'ORTHO':
-                    bpy.ops.view3d.view_ortho()
+                # In Blender 4.x, calling view_axis automatically handles ortho switching.
+                # The explicit call to view_ortho() is removed.
+                area.spaces.active.region_3d.view_perspective = 'ORTHO'
                 bpy.ops.view3d.view_axis(type=self.view_type)
 
             bpy.ops.view3d.view_all(center=False)

--- a/properties.py
+++ b/properties.py
@@ -79,6 +79,10 @@ class CADToolsSettings(bpy.types.PropertyGroup):
     show_grid: bpy.props.BoolProperty(name="Show Grid", default=True, update=update_units_and_grid)
     grid_spacing: bpy.props.FloatProperty(name="Grid Spacing", default=0.01, min=0.0001, subtype='DISTANCE', update=update_units_and_grid)
 
+    show_grid_dimensions: bpy.props.BoolProperty(name="Show Dimensions", default=False, description="Display grid scale markings in the viewport", update=update_units_and_grid)
+    grid_dimension_font_size: bpy.props.IntProperty(name="Font Size", default=12, min=8, max=72, description="Font size for the grid dimensions", update=update_units_and_grid)
+    grid_dimension_color: bpy.props.FloatVectorProperty(name="Color", subtype='COLOR', default=(1.0, 1.0, 1.0), min=0.0, max=1.0, description="Color for the grid dimensions", update=update_units_and_grid)
+
     show_ref_sketches: bpy.props.BoolProperty(name="Show/Hide Sketches", default=True, update=update_ref_image_visibility)
     top_image: bpy.props.PointerProperty(type=ReferenceImageSettings)
     front_image: bpy.props.PointerProperty(type=ReferenceImageSettings)

--- a/ui/draw_handlers.py
+++ b/ui/draw_handlers.py
@@ -1,0 +1,118 @@
+import bpy
+import blf
+import gpu
+from mathutils import Vector
+from bpy_extras.view3d_utils import region_2d_to_location_3d
+
+def get_view_orientation(context):
+    """Returns the orientation of the 3D view, e.g., 'TOP', 'FRONT', 'PERSP', etc."""
+    region_3d = context.space_data.region_3d
+    view_quat = region_3d.view_rotation
+
+    # These vectors define the standard view orientations
+    view_vectors = {
+        'TOP': Vector((0, 0, 1)),
+        'BOTTOM': Vector((0, 0, -1)),
+        'FRONT': Vector((0, -1, 0)),
+        'BACK': Vector((0, 1, 0)),
+        'RIGHT': Vector((1, 0, 0)),
+        'LEFT': Vector((-1, 0, 0)),
+    }
+
+    # The camera's forward vector is the Z-axis of its rotation
+    forward_vector = view_quat @ Vector((0, 0, -1))
+
+    for name, vec in view_vectors.items():
+        if forward_vector.dot(vec) > 0.99:
+            return name
+
+    return 'PERSP' # If not aligned with any axis, assume perspective/user view
+
+def draw_grid_dimensions_callback(context):
+    """Draws dimension labels on the grid in the 3D viewport."""
+    settings = context.scene.cad_tool_settings
+    if not settings.show_grid_dimensions:
+        return
+
+    space = context.space_data
+    if space.type != 'VIEW_3D' or not space.overlay.show_floor:
+        return
+
+    # Only draw in orthographic, axis-aligned views for clarity
+    if space.region_3d.view_perspective != 'ORTHO':
+        return
+
+    orientation = get_view_orientation(context)
+    if orientation == 'PERSP':
+        return
+
+    # --- Setup Drawing ---
+    font_id = 0  # Default font
+    blf.size(font_id, settings.grid_dimension_font_size)
+    # Set the color with alpha
+    color = (*settings.grid_dimension_color, 1.0)
+    blf.color(font_id, *color)
+
+    region = context.region
+    region_3d = space.region_3d
+
+    # Get visible range
+    view_center_3d = region_2d_to_location_3d(region, region_3d, region.width / 2, region.height / 2, region_3d.view_location)
+    zoom_factor = region_3d.view_distance * 0.2
+
+    grid_scale = space.overlay.grid_scale
+    if grid_scale <= 0: return
+
+    # --- Draw Labels ---
+    def draw_label(text, coord_3d):
+        coord_2d = bpy.context.region_data.view3d_to_region_2d(region, coord_3d, default=None)
+        if coord_2d is None: return
+        blf.position(font_id, coord_2d.x, coord_2d.y, 0)
+        blf.draw(font_id, text)
+
+    # Determine which axes to label based on orientation
+    if orientation in ['TOP', 'BOTTOM']:
+        x_axis, y_axis = 0, 1
+    elif orientation in ['FRONT', 'BACK']:
+        x_axis, y_axis = 0, 2
+    elif orientation in ['LEFT', 'RIGHT']:
+        x_axis, y_axis = 1, 2
+    else:
+        return
+
+    # Draw labels along the horizontal axis
+    for i in range(-50, 51):
+        if i == 0: continue
+        pos = i * grid_scale
+        coord = Vector((0,0,0))
+        coord[x_axis] = pos
+        label_text = bpy.utils.units.to_string_pretty(pos, context.scene.unit_settings)
+        draw_label(label_text, coord)
+
+    # Draw labels along the vertical axis
+    for i in range(-50, 51):
+        if i == 0: continue
+        pos = i * grid_scale
+        coord = Vector((0,0,0))
+        coord[y_axis] = pos
+        label_text = bpy.utils.units.to_string_pretty(pos, context.scene.unit_settings)
+        draw_label(label_text, coord)
+
+
+# --- Registration ---
+draw_handler = None
+
+def register():
+    """Adds the draw handler to the 3D view."""
+    global draw_handler
+    if draw_handler is None:
+        draw_handler = bpy.types.SpaceView3D.draw_handler_add(
+            draw_grid_dimensions_callback, (bpy.context,), 'WINDOW', 'POST_PIXEL'
+        )
+
+def unregister():
+    """Removes the draw handler from the 3D view."""
+    global draw_handler
+    if draw_handler is not None:
+        bpy.types.SpaceView3D.draw_handler_remove(draw_handler, 'WINDOW')
+        draw_handler = None

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -86,6 +86,13 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
         row = unit_box.row(align=True)
         row.prop(settings, "show_grid", text="Show Grid")
         row.prop(settings, "grid_spacing", text="Spacing")
+        unit_box.separator()
+        unit_box.prop(settings, "show_grid_dimensions", text="Show Dimensions")
+        if settings.show_grid_dimensions:
+            col = unit_box.column(align=True)
+            col.use_property_split = True
+            col.prop(settings, "grid_dimension_font_size", text="Font Size")
+            col.prop(settings, "grid_dimension_color", text="Color")
 
         # --- 2D Sketching Section ---
         sketch_box = layout.box()


### PR DESCRIPTION
This commit resolves an `AttributeError` in the view navigator and implements a new feature to display grid dimensions in the 3D viewport.

The `AttributeError` was caused by a call to the `bpy.ops.view3d.view_ortho()` operator, which has been removed in recent Blender versions. This has been fixed by replacing the operator call with a direct assignment to `region_3d.view_perspective = 'ORTHO'`, which is the correct method in Blender 4.x.

The new grid dimension feature adds scale markings to the viewport grid. Key additions include:
- `properties.py`: New `PropertyGroup` settings to toggle the feature and customize font size and color.
- `ui/draw_handlers.py`: A new file containing the draw handler logic to display text labels on the grid in orthographic views.
- `ui/panel.py`: A new section in the UI to control the grid dimension settings.
- `__init__.py`: The new draw handler module is now registered and unregistered with the addon.