### PR TITLE
Fix multiple API-related errors for Blender 4.x

### DIFF
--- a/operators/op_3d.py
+++ b/operators/op_3d.py
@@ -38,16 +38,23 @@ class MESH_OT_create_hole(bpy.types.Operator):
         target_obj = context.active_object
         cursor_loc = context.scene.cursor.location
         bm = bmesh.new()
-        bmesh.ops.create_cone(bm, cap_ends=True, segments=64, radius1=self.diameter / 2, radius2=self.diameter / 2, depth=self.depth, location=(0, 0, -self.depth / 2))
+
+        # Main hole
+        cone_main = bmesh.ops.create_cone(bm, cap_ends=True, segments=64, radius1=self.diameter / 2, radius2=self.diameter / 2, depth=self.depth)
+        bmesh.ops.translate(bm, verts=cone_main['verts'], vec=(0, 0, -self.depth / 2))
+
         if self.hole_type == 'COUNTERBORE':
             if self.cb_diameter <= self.diameter or self.cb_depth <= 0:
                 self.report({'ERROR'}, "Counterbore dimensions must be larger than hole.")
                 return {'CANCELLED'}
-            bmesh.ops.create_cone(bm, cap_ends=True, segments=64, radius1=self.cb_diameter / 2, radius2=self.cb_diameter / 2, depth=self.cb_depth, location=(0, 0, self.cb_depth / 2))
+            cone_cb = bmesh.ops.create_cone(bm, cap_ends=True, segments=64, radius1=self.cb_diameter / 2, radius2=self.cb_diameter / 2, depth=self.cb_depth)
+            bmesh.ops.translate(bm, verts=cone_cb['verts'], vec=(0, 0, self.cb_depth / 2))
+
         elif self.hole_type == 'COUNTERSINK':
             cs_radius = self.diameter / 2
             cs_depth = cs_radius / math.tan(math.radians(self.cs_angle / 2))
-            bmesh.ops.create_cone(bm, cap_ends=True, segments=64, radius1=cs_radius, radius2=0, depth=cs_depth, location=(0, 0, cs_depth / 2))
+            cone_cs = bmesh.ops.create_cone(bm, cap_ends=True, segments=64, radius1=cs_radius, radius2=0, depth=cs_depth)
+            bmesh.ops.translate(bm, verts=cone_cs['verts'], vec=(0, 0, cs_depth / 2))
         
         cutter_mesh = bpy.data.meshes.new("HoleCutter_Mesh")
         bm.to_mesh(cutter_mesh)

--- a/operators/reference_manager.py
+++ b/operators/reference_manager.py
@@ -51,7 +51,7 @@ class IMAGE_OT_load_reference(bpy.types.Operator, ImportHelper):
             empty.empty_display_size = image_settings.size
             empty.location.x = image_settings.offset_x
             empty.location.y = image_settings.offset_y
-            empty.image_opacity = image_settings.opacity
+            empty.color[3] = image_settings.opacity # Use alpha channel of color for opacity
             empty.hide_viewport = not settings.show_ref_sketches
 
         return {'FINISHED'}

--- a/operators/sketch_tools.py
+++ b/operators/sketch_tools.py
@@ -75,8 +75,7 @@ class SKETCH_OT_draw_line(SketcherModalBase):
         self.batch_line = None
         self.batch_snap = None
         # Shaders - created once
-        self.shader_3d = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
-        self.shader_2d = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+        self.shader = gpu.shader.from_builtin('UNIFORM_COLOR')
         context.area.header_text_set("Line: Click for start point. ESC to cancel.")
         return super().invoke(context, event)
 
@@ -96,7 +95,7 @@ class SKETCH_OT_draw_line(SketcherModalBase):
             p_2d = location_3d_to_region_2d(context.region, context.region_data, self.snapped_vertex_pos)
             if p_2d:
                 circle_verts = draw_circle_3d(p_2d, 8, Vector((0,0,1)), segments=12)
-                self.batch_snap = batch_for_shader(self.shader_2d, 'LINE_STRIP', {"pos": circle_verts})
+                self.batch_snap = batch_for_shader(self.shader, 'LINE_STRIP', {"pos": circle_verts})
             else:
                 self.batch_snap = None
         else:
@@ -104,7 +103,7 @@ class SKETCH_OT_draw_line(SketcherModalBase):
 
         if self.points:
             line_verts = [self.points[0], self.mouse_pos_3d]
-            self.batch_line = batch_for_shader(self.shader_3d, 'LINES', {"pos": line_verts})
+            self.batch_line = batch_for_shader(self.shader, 'LINES', {"pos": line_verts})
         else:
             self.batch_line = None
 
@@ -126,15 +125,15 @@ class SKETCH_OT_draw_line(SketcherModalBase):
     def draw_callback_px(self, context):
         # Draw snapping indicator
         if self.batch_snap:
-            self.shader_2d.bind()
-            self.shader_2d.uniform_float("color", (0.1, 0.8, 0.1, 1.0))
-            self.batch_snap.draw(self.shader_2d)
+            self.shader.bind()
+            self.shader.uniform_float("color", (0.1, 0.8, 0.1, 1.0))
+            self.batch_snap.draw(self.shader)
 
         # Draw the line preview
         if self.batch_line:
-            self.shader_3d.bind()
-            self.shader_3d.uniform_float("color", (0.1, 0.1, 0.8, 1.0))
-            self.batch_line.draw(self.shader_3d)
+            self.shader.bind()
+            self.shader.uniform_float("color", (0.1, 0.1, 0.8, 1.0))
+            self.batch_line.draw(self.shader)
 
     def finish_drawing(self, context):
         if len(self.points) < 2:

--- a/properties.py
+++ b/properties.py
@@ -8,7 +8,7 @@ def update_ref_image_property(self, context):
         self.empty_ref.empty_display_size = self.size
         self.empty_ref.location.x = self.offset_x
         self.empty_ref.location.y = self.offset_y
-        self.empty_ref.image_opacity = self.opacity
+        self.empty_ref.color[3] = self.opacity # Use alpha channel of color for opacity
 
 def update_ref_image_visibility(self, context):
     """Toggles the visibility of all reference image empties."""


### PR DESCRIPTION
This commit resolves three distinct errors caused by API changes in recent versions of Blender.

1.  **Fix `TypeError` in `op_3d.py`**: The `location` keyword argument has been removed from `bmesh.ops.create_cone`. The code has been updated to create the cone at the origin and then translate it to the desired position using `bmesh.ops.translate`.

2.  **Fix `AttributeError` in `reference_manager.py`**: The `image_opacity` property for image empties is no longer available. The fix involves using the alpha channel of the object's `color` property (`object.color[3]`) to control opacity. This change was applied in both `reference_manager.py` and the corresponding update handler in `properties.py`.

3.  **Fix `ValueError` in `sketch_tools.py`**: The built-in shader names `'3D_UNIFORM_COLOR'` and `'2D_UNIFORM_COLOR'` are deprecated. They have been replaced with the new, correct name `'UNIFORM_COLOR'`.