### PR TITLE
Fix cursor attribute error and improve grid visuals

### DIFF
--- a/operators/sketch_tools.py
+++ b/operators/sketch_tools.py
@@ -17,7 +17,7 @@ class SketcherModalBase(bpy.types.Operator):
         self.active = True
         self.draw_handle = bpy.types.SpaceView3D.draw_handler_add(self.draw_callback_px, (context,), 'WINDOW', 'POST_VIEW')
         context.window_manager.modal_handler_add(self)
-        self.original_cursor = context.window.cursor
+        self.original_cursor = context.window.cursor_get()
         context.window.cursor_set('CROSSHAIR')
         return {'RUNNING_MODAL'}
 

--- a/properties.py
+++ b/properties.py
@@ -62,6 +62,15 @@ def update_units_and_grid(self, context):
                 if space.type == 'VIEW_3D':
                     space.overlay.show_floor = settings.show_grid
                     space.overlay.grid_scale = settings.grid_spacing
+
+                    # Adjust subdivisions to keep the grid visually clean at small scales
+                    if settings.grid_spacing < 0.01: # e.g., < 1cm
+                        space.overlay.grid_subdivisions = 1
+                    elif settings.grid_spacing < 0.1: # e.g., < 10cm
+                        space.overlay.grid_subdivisions = 2
+                    else:
+                        space.overlay.grid_subdivisions = 10
+
                     space.tag_redraw()
 
 


### PR DESCRIPTION
This commit addresses two issues: an `AttributeError` related to the window cursor and a bug where the grid display would not update correctly for small-scale units.

1.  **Fix `AttributeError` in `sketch_tools.py`**: The `context.window.cursor` attribute was removed in the Blender 4.x API. The code has been updated to use the correct `context.window.cursor_get()` method to retrieve the current cursor style, resolving the error during modal operator invocation.

2.  **Fix Grid Spacing Visuals**: The grid would become visually unusable when set to small scales (e.g., 1cm) because the number of subdivisions remained fixed at 10, making the grid too dense. The `update_units_and_grid` function in `properties.py` has been improved to dynamically adjust the `grid_subdivisions` based on the `grid_scale`. This ensures the grid remains clear and legible at all scales.