### PR TITLE
Fix `AttributeError` for window cursor handling

### DIFF
--- a/operators/sketch_tools.py
+++ b/operators/sketch_tools.py
@@ -17,12 +17,11 @@ class SketcherModalBase(bpy.types.Operator):
         self.active = True
         self.draw_handle = bpy.types.SpaceView3D.draw_handler_add(self.draw_callback_px, (context,), 'WINDOW', 'POST_VIEW')
         context.window_manager.modal_handler_add(self)
-        self.original_cursor = context.window.cursor_get()
         context.window.cursor_set('CROSSHAIR')
         return {'RUNNING_MODAL'}
 
     def cleanup(self, context):
-        context.window.cursor_set(self.original_cursor)
+        context.window.cursor_set('DEFAULT')
         context.area.header_text_set(None)
         if self.draw_handle:
             bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, 'WINDOW')


### PR DESCRIPTION
This commit resolves an `AttributeError: 'Window' object has no attribute 'cursor_get'` that occurred when invoking modal sketch operators.

The previous fix was incorrect. The Blender 4.x Python API does not provide a `cursor_get()` method. The correct pattern for modal operators is to set a desired cursor (e.g., 'CROSSHAIR') upon invocation and to reset it to the standard `'DEFAULT'` cursor when the operator finishes.

The `SketcherModalBase` class in `operators/sketch_tools.py` has been updated to follow this pattern. The code no longer attempts to store the original cursor state, and the `cleanup` method now robustly sets the cursor back to `'DEFAULT'`.