### PR TITLE
I am stabilizing cursor handling by disabling it.

### DIFF
--- a/operators/sketch_tools.py
+++ b/operators/sketch_tools.py
@@ -17,11 +17,11 @@ class SketcherModalBase(bpy.types.Operator):
         self.active = True
         self.draw_handle = bpy.types.SpaceView3D.draw_handler_add(self.draw_callback_px, (context,), 'WINDOW', 'POST_VIEW')
         context.window_manager.modal_handler_add(self)
-        context.window.cursor_set('CROSSHAIR')
+        # context.window.cursor_set('CROSSHAIR') # Temporarily disabled to fix error
         return {'RUNNING_MODAL'}
 
     def cleanup(self, context):
-        context.window.cursor_set('DEFAULT')
+        # context.window.cursor_set('DEFAULT') # Temporarily disabled to fix error
         context.area.header_text_set(None)
         if self.draw_handle:
             bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, 'WINDOW')


### PR DESCRIPTION
This commit addresses a recurring and contradictory `AttributeError` related to `cursor_get` and `cursor_set` when invoking modal sketch operators. Previous attempts to fix this using the modern API were unsuccessful, suggesting a deeper issue, possibly with stale bytecode.

To ensure the addon is usable and stable, this commit temporarily disables the cursor-changing functionality altogether. The calls to `context.window.cursor_set()` in the `invoke` and `cleanup` methods of the `SketcherModalBase` class have been commented out.

This prevents the error from occurring, allowing the sketch tools to be used, although without the custom 'CROSSHAIR' cursor. This provides a stable baseline from which the cursor feature can be revisited later if necessary.