### PR TITLE
Fix `AttributeError` due to vector dimension mismatch

### DIFF
--- a/operators/sketch_tools.py
+++ b/operators/sketch_tools.py
@@ -93,7 +93,7 @@ class SKETCH_OT_draw_line(SketcherModalBase):
         if self.snapped_vertex_pos:
             p_2d = location_3d_to_region_2d(context.region, context.region_data, self.snapped_vertex_pos)
             if p_2d:
-                circle_verts = draw_circle_3d(p_2d, 8, Vector((0,0,1)), segments=12)
+                circle_verts = draw_circle_3d(p_2d.to_3d(), 8, Vector((0,0,1)), segments=12)
                 self.batch_snap = batch_for_shader(self.shader, 'LINE_STRIP', {"pos": circle_verts})
             else:
                 self.batch_snap = None


### PR DESCRIPTION
This commit resolves an `AttributeError: Vector addition: vectors must have the same dimensions for this operation` that occurred in the snap indicator drawing function.

The error was caused by passing a 2D screen vector (`p_2d`) from `location_3d_to_region_2d` directly to the `draw_circle_3d` utility function, which expected a 3D vector for its position argument.

The fix is to convert the 2D vector to a 3D vector with a zero Z-component before passing it to the function. The call site in `operators/sketch_tools.py` has been changed from `draw_circle_3d(p_2d, ...)` to `draw_circle_3d(p_2d.to_3d(), ...)`.