### PR TITLE
feat: Make all UI sections collapsible

### DIFF
--- a/properties.py
+++ b/properties.py
@@ -76,6 +76,13 @@ def update_units_and_grid(self, context):
 
 class CADToolsSettings(bpy.types.PropertyGroup):
     """Stores settings for the CAD addon."""
+    # --- UI Expansion States ---
+    expand_view_navigator: bpy.props.BoolProperty(default=True)
+    expand_reference_sketches: bpy.props.BoolProperty(default=True)
+    expand_units_and_grid: bpy.props.BoolProperty(default=True)
+    expand_2d_sketching: bpy.props.BoolProperty(default=True)
+    expand_3d_operations: bpy.props.BoolProperty(default=True)
+
     pan_x: bpy.props.FloatProperty(name="Pan Left/Right", default=0.0, update=update_view_pan)
     pan_y: bpy.props.FloatProperty(name="Pan Up/Down", default=0.0, update=update_view_pan)
     pan_origin: bpy.props.FloatVectorProperty(name="Pan Origin", subtype='TRANSLATION')

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -49,77 +49,82 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
         
         # --- View Navigator Section ---
         view_box = layout.box()
-        view_box.label(text="View Navigator", icon='VIEW3D')
-        row = view_box.row(align=True)
-        row.operator(VIEW_OT_set_view_axis.bl_idname, text="Top").view_type = 'TOP'
-        row.operator(VIEW_OT_set_view_axis.bl_idname, text="Front").view_type = 'FRONT'
-        row.operator(VIEW_OT_set_view_axis.bl_idname, text="Right").view_type = 'RIGHT'
-        row = view_box.row(align=True)
-        row.operator(VIEW_OT_set_view_axis.bl_idname, text="Bottom").view_type = 'BOTTOM'
-        row.operator(VIEW_OT_set_view_axis.bl_idname, text="Back").view_type = 'BACK'
-        row.operator(VIEW_OT_set_view_axis.bl_idname, text="Left").view_type = 'LEFT'
-        row = view_box.row(align=True)
-        row.operator(VIEW_OT_set_view_axis.bl_idname, text="Perspective", icon='VIEW_PERSPECTIVE').view_type = 'PERSP'
-        col = view_box.column(align=True)
-        col.prop(settings, "pan_x", text="L/R")
-        col.prop(settings, "pan_y", text="U/D")
+        view_box.prop(settings, "expand_view_navigator", text="View Navigator", icon='VIEW3D', emboss=False)
+        if settings.expand_view_navigator:
+            row = view_box.row(align=True)
+            row.operator(VIEW_OT_set_view_axis.bl_idname, text="Top").view_type = 'TOP'
+            row.operator(VIEW_OT_set_view_axis.bl_idname, text="Front").view_type = 'FRONT'
+            row.operator(VIEW_OT_set_view_axis.bl_idname, text="Right").view_type = 'RIGHT'
+            row = view_box.row(align=True)
+            row.operator(VIEW_OT_set_view_axis.bl_idname, text="Bottom").view_type = 'BOTTOM'
+            row.operator(VIEW_OT_set_view_axis.bl_idname, text="Back").view_type = 'BACK'
+            row.operator(VIEW_OT_set_view_axis.bl_idname, text="Left").view_type = 'LEFT'
+            row = view_box.row(align=True)
+            row.operator(VIEW_OT_set_view_axis.bl_idname, text="Perspective", icon='VIEW_PERSPECTIVE').view_type = 'PERSP'
+            col = view_box.column(align=True)
+            col.prop(settings, "pan_x", text="L/R")
+            col.prop(settings, "pan_y", text="U/D")
 
         # --- Reference Sketches Section ---
         ref_box = layout.box()
-        ref_box.label(text="Reference Sketches", icon='IMAGE')
-        ref_box.prop(settings, "show_ref_sketches", text="Show/Hide All", toggle=True)
-        self._draw_ref_image_ui(ref_box, settings, "Top", "TOP")
-        self._draw_ref_image_ui(ref_box, settings, "Front", "FRONT")
-        self._draw_ref_image_ui(ref_box, settings, "Right", "RIGHT")
-        self._draw_ref_image_ui(ref_box, settings, "Bottom", "BOTTOM")
-        self._draw_ref_image_ui(ref_box, settings, "Back", "BACK")
-        self._draw_ref_image_ui(ref_box, settings, "Left", "LEFT")
+        ref_box.prop(settings, "expand_reference_sketches", text="Reference Sketches", icon='IMAGE', emboss=False)
+        if settings.expand_reference_sketches:
+            ref_box.prop(settings, "show_ref_sketches", text="Show/Hide All", toggle=True)
+            self._draw_ref_image_ui(ref_box, settings, "Top", "TOP")
+            self._draw_ref_image_ui(ref_box, settings, "Front", "FRONT")
+            self._draw_ref_image_ui(ref_box, settings, "Right", "RIGHT")
+            self._draw_ref_image_ui(ref_box, settings, "Bottom", "BOTTOM")
+            self._draw_ref_image_ui(ref_box, settings, "Back", "BACK")
+            self._draw_ref_image_ui(ref_box, settings, "Left", "LEFT")
 
         # --- Units & Grid Section ---
         unit_box = layout.box()
-        unit_box.label(text="Units & Grid", icon='GRID')
-        row = unit_box.row(align=True)
-        row.prop(settings, "unit_system", expand=True)
-        if settings.unit_system == 'METRIC':
+        unit_box.prop(settings, "expand_units_and_grid", text="Units & Grid", icon='GRID', emboss=False)
+        if settings.expand_units_and_grid:
             row = unit_box.row(align=True)
-            row.prop(settings, "metric_unit", expand=True)
-        row = unit_box.row(align=True)
-        row.prop(settings, "show_grid", text="Show Grid")
-        row.prop(settings, "grid_spacing", text="Spacing")
-        unit_box.separator()
-        unit_box.prop(settings, "show_grid_dimensions", text="Show Dimensions")
-        if settings.show_grid_dimensions:
-            col = unit_box.column(align=True)
-            col.use_property_split = True
-            col.prop(settings, "grid_dimension_font_size", text="Font Size")
-            col.prop(settings, "grid_dimension_color", text="Color")
+            row.prop(settings, "unit_system", expand=True)
+            if settings.unit_system == 'METRIC':
+                row = unit_box.row(align=True)
+                row.prop(settings, "metric_unit", expand=True)
+            row = unit_box.row(align=True)
+            row.prop(settings, "show_grid", text="Show Grid")
+            row.prop(settings, "grid_spacing", text="Spacing")
+            unit_box.separator()
+            unit_box.prop(settings, "show_grid_dimensions", text="Show Dimensions")
+            if settings.show_grid_dimensions:
+                col = unit_box.column(align=True)
+                col.use_property_split = True
+                col.prop(settings, "grid_dimension_font_size", text="Font Size")
+                col.prop(settings, "grid_dimension_color", text="Color")
 
         # --- 2D Sketching Section ---
         sketch_box = layout.box()
-        sketch_box.label(text="2D Sketching", icon='GREASEPENCIL')
-        row = sketch_box.row(align=True)
-        row.operator(SKETCH_OT_draw_line.bl_idname, text="Line", icon='CURVE_PATH')
-        # The following operators are not yet implemented
-        # row.operator(SKETCH_OT_draw_rectangle.bl_idname, text="Rectangle", icon='MESH_PLANE')
-        # row.operator(SKETCH_OT_draw_circle.bl_idname, text="Circle", icon='MESH_CIRCLE')
-        # row = sketch_box.row(align=True)
-        # row.operator(SKETCH_OT_draw_polyline.bl_idname, text="Poly-line", icon='MOD_MULTIRES')
-        # row.operator(SKETCH_OT_draw_arc.bl_idname, text="Arc", icon='CURVE_NCIRCLE')
-        # row.operator(SKETCH_OT_draw_circle_diameter.bl_idname, text="2P Circle", icon='MESH_CIRCLE')
-        col = sketch_box.column(align=True)
-        col.prop(settings, "use_grid_snap")
-        col.prop(settings, "use_vertex_snap")
+        sketch_box.prop(settings, "expand_2d_sketching", text="2D Sketching", icon='GREASEPENCIL', emboss=False)
+        if settings.expand_2d_sketching:
+            row = sketch_box.row(align=True)
+            row.operator(SKETCH_OT_draw_line.bl_idname, text="Line", icon='CURVE_PATH')
+            # The following operators are not yet implemented
+            # row.operator(SKETCH_OT_draw_rectangle.bl_idname, text="Rectangle", icon='MESH_PLANE')
+            # row.operator(SKETCH_OT_draw_circle.bl_idname, text="Circle", icon='MESH_CIRCLE')
+            # row = sketch_box.row(align=True)
+            # row.operator(SKETCH_OT_draw_polyline.bl_idname, text="Poly-line", icon='MOD_MULTIRES')
+            # row.operator(SKETCH_OT_draw_arc.bl_idname, text="Arc", icon='CURVE_NCIRCLE')
+            # row.operator(SKETCH_OT_draw_circle_diameter.bl_idname, text="2P Circle", icon='MESH_CIRCLE')
+            col = sketch_box.column(align=True)
+            col.prop(settings, "use_grid_snap")
+            col.prop(settings, "use_vertex_snap")
 
         # --- 3D Operations Section ---
         op_box = layout.box()
-        op_box.label(text="3D Operations", icon='MODIFIER')
-        op_box.operator(MESH_OT_simple_extrude.bl_idname, text="Extrude", icon='MOD_SOLIDIFY')
-        op_box.operator(MESH_OT_inset_faces.bl_idname, text="Inset", icon='FACESEL')
-        op_box.operator(MESH_OT_offset_edges.bl_idname, text="Offset", icon='EDGESEL')
-        op_box.operator(MESH_OT_bevel_edges.bl_idname, text="Bevel", icon='MOD_BEVEL')
-        op_box.separator()
-        op_box.operator(MESH_OT_create_hole.bl_idname, text="Hole Tool", icon='MESH_CYLINDER')
-        op_box.operator(MESH_OT_create_gear.bl_idname, text="Spur Gear", icon='MOD_ARRAY')
+        op_box.prop(settings, "expand_3d_operations", text="3D Operations", icon='MODIFIER', emboss=False)
+        if settings.expand_3d_operations:
+            op_box.operator(MESH_OT_simple_extrude.bl_idname, text="Extrude", icon='MOD_SOLIDIFY')
+            op_box.operator(MESH_OT_inset_faces.bl_idname, text="Inset", icon='FACESEL')
+            op_box.operator(MESH_OT_offset_edges.bl_idname, text="Offset", icon='EDGESEL')
+            op_box.operator(MESH_OT_bevel_edges.bl_idname, text="Bevel", icon='MOD_BEVEL')
+            op_box.separator()
+            op_box.operator(MESH_OT_create_hole.bl_idname, text="Hole Tool", icon='MESH_CYLINDER')
+            op_box.operator(MESH_OT_create_gear.bl_idname, text="Spur Gear", icon='MOD_ARRAY')
 
 
 classes = (


### PR DESCRIPTION
This commit implements collapsible sections for the main panel UI, allowing you to expand or collapse each part of the tool panel. This improves UI organization and makes it easier to focus on specific toolsets.

- **`properties.py`**: I added five new `BoolProperty` definitions to the `CADToolsSettings` class (`expand_view_navigator`, `expand_reference_sketches`, etc.) to store the expansion state of each UI section. They default to `True`.

- **`ui/panel.py`**: I updated the `draw()` method to use the new boolean properties. I replaced the static `box.label()` for each section with a `box.prop()` call, which creates a clickable header. I then wrapped the content of each section in an `if` block, making it visible only when the corresponding property is true.