### PR TITLE
refactor(ui): Refine collapsible panel appearance and behavior

### DIFF
--- a/properties.py
+++ b/properties.py
@@ -78,10 +78,10 @@ class CADToolsSettings(bpy.types.PropertyGroup):
     """Stores settings for the CAD addon."""
     # --- UI Expansion States ---
     expand_view_navigator: bpy.props.BoolProperty(default=True)
-    expand_reference_sketches: bpy.props.BoolProperty(default=True)
-    expand_units_and_grid: bpy.props.BoolProperty(default=True)
-    expand_2d_sketching: bpy.props.BoolProperty(default=True)
-    expand_3d_operations: bpy.props.BoolProperty(default=True)
+    expand_reference_sketches: bpy.props.BoolProperty(default=False)
+    expand_units_and_grid: bpy.props.BoolProperty(default=False)
+    expand_2d_sketching: bpy.props.BoolProperty(default=False)
+    expand_3d_operations: bpy.props.BoolProperty(default=False)
 
     pan_x: bpy.props.FloatProperty(name="Pan Left/Right", default=0.0, update=update_view_pan)
     pan_y: bpy.props.FloatProperty(name="Pan Up/Down", default=0.0, update=update_view_pan)

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -49,7 +49,7 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
         
         # --- View Navigator Section ---
         view_box = layout.box()
-        view_box.prop(settings, "expand_view_navigator", text="View Navigator", icon='VIEW3D', emboss=False)
+        view_box.prop(settings, "expand_view_navigator", text="View Navigator", icon='VIEW3D')
         if settings.expand_view_navigator:
             row = view_box.row(align=True)
             row.operator(VIEW_OT_set_view_axis.bl_idname, text="Top").view_type = 'TOP'
@@ -67,7 +67,7 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
 
         # --- Reference Sketches Section ---
         ref_box = layout.box()
-        ref_box.prop(settings, "expand_reference_sketches", text="Reference Sketches", icon='IMAGE', emboss=False)
+        ref_box.prop(settings, "expand_reference_sketches", text="Reference Sketches", icon='IMAGE')
         if settings.expand_reference_sketches:
             ref_box.prop(settings, "show_ref_sketches", text="Show/Hide All", toggle=True)
             self._draw_ref_image_ui(ref_box, settings, "Top", "TOP")
@@ -79,7 +79,7 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
 
         # --- Units & Grid Section ---
         unit_box = layout.box()
-        unit_box.prop(settings, "expand_units_and_grid", text="Units & Grid", icon='GRID', emboss=False)
+        unit_box.prop(settings, "expand_units_and_grid", text="Units & Grid", icon='GRID')
         if settings.expand_units_and_grid:
             row = unit_box.row(align=True)
             row.prop(settings, "unit_system", expand=True)
@@ -99,7 +99,7 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
 
         # --- 2D Sketching Section ---
         sketch_box = layout.box()
-        sketch_box.prop(settings, "expand_2d_sketching", text="2D Sketching", icon='GREASEPENCIL', emboss=False)
+        sketch_box.prop(settings, "expand_2d_sketching", text="2D Sketching", icon='GREASEPENCIL')
         if settings.expand_2d_sketching:
             row = sketch_box.row(align=True)
             row.operator(SKETCH_OT_draw_line.bl_idname, text="Line", icon='CURVE_PATH')
@@ -116,7 +116,7 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
 
         # --- 3D Operations Section ---
         op_box = layout.box()
-        op_box.prop(settings, "expand_3d_operations", text="3D Operations", icon='MODIFIER', emboss=False)
+        op_box.prop(settings, "expand_3d_operations", text="3D Operations", icon='MODIFIER')
         if settings.expand_3d_operations:
             op_box.operator(MESH_OT_simple_extrude.bl_idname, text="Extrude", icon='MOD_SOLIDIFY')
             op_box.operator(MESH_OT_inset_faces.bl_idname, text="Inset", icon='FACESEL')


### PR DESCRIPTION
This commit refines the collapsible UI sections based on your feedback.

- **Default State**: Only the first panel ("View Navigator") is now expanded by default. The `default` values for the other `expand_...` boolean properties in `properties.py` have been set to `False`.

- **UI Style**: The `emboss=False` argument has been removed from the `UILayout.prop()` calls in `ui/panel.py`. This reverts the section headers to the standard Blender style, which includes the arrow (twistie) icon for collapsing and expanding, making the behavior more intuitive for you.