### PR TITLE
refactor(core): Split settings into Scene and Object properties

### DIFF
--- a/operators/feature_manager.py
+++ b/operators/feature_manager.py
@@ -25,7 +25,7 @@ class OBJECT_OT_add_feature(bpy.types.Operator):
         # For now, just a placeholder.
         self.report({'INFO'}, f"Placeholder: Add {self.feature_type} feature.")
         # Example of how it would work:
-        # new_feature = obj.cad_tool_settings.feature_tree.add()
+        # new_feature = obj.object_cad_settings.feature_tree.add()
         # new_feature.name = self.feature_type.capitalize()
         # new_feature.type = self.feature_type
         return {'FINISHED'}
@@ -40,11 +40,11 @@ class OBJECT_OT_remove_feature(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.object
-        return obj and obj.cad_tool_settings and len(obj.cad_tool_settings.feature_tree) > 0
+        return obj and obj.object_cad_settings and len(obj.object_cad_settings.feature_tree) > 0
 
     def execute(self, context):
         obj = context.object
-        settings = obj.cad_tool_settings
+        settings = obj.object_cad_settings
         index = settings.active_feature_index
 
         # In a real implementation, we would remove the feature.
@@ -73,11 +73,11 @@ class OBJECT_OT_move_feature(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.object
-        return obj and obj.cad_tool_settings and len(obj.cad_tool_settings.feature_tree) > 1
+        return obj and obj.object_cad_settings and len(obj.object_cad_settings.feature_tree) > 1
 
     def execute(self, context):
         obj = context.object
-        settings = obj.cad_tool_settings
+        settings = obj.object_cad_settings
         index = settings.active_feature_index
 
         # In a real implementation, we would move the feature.

--- a/operators/reference_manager.py
+++ b/operators/reference_manager.py
@@ -13,7 +13,7 @@ class IMAGE_OT_load_reference(bpy.types.Operator, ImportHelper):
     view_type: bpy.props.StringProperty()
 
     def execute(self, context):
-        settings = context.scene.cad_tool_settings
+        settings = context.scene.scene_cad_settings
         image_settings_key = f"{self.view_type.lower()}_image"
         image_settings = getattr(settings, image_settings_key)
         empty_name = f"ref_{self.view_type.lower()}"
@@ -65,7 +65,7 @@ class IMAGE_OT_clear_reference(bpy.types.Operator):
     view_type: bpy.props.StringProperty()
 
     def execute(self, context):
-        settings = context.scene.cad_tool_settings
+        settings = context.scene.scene_cad_settings
         image_settings_key = f"{self.view_type.lower()}_image"
         image_settings = getattr(settings, image_settings_key)
 

--- a/operators/sketch_tools.py
+++ b/operators/sketch_tools.py
@@ -29,7 +29,7 @@ class SketcherModalBase(bpy.types.Operator):
 
     def get_snapped_point(self, context, event):
         """Calculates the 3D mouse position with snapping."""
-        settings = context.scene.cad_tool_settings
+        settings = context.scene.scene_cad_settings
         snapped_vertex_pos = None
 
         temp_mouse_pos = mouse_to_plane_coord(context, event)

--- a/operators/view_navigator.py
+++ b/operators/view_navigator.py
@@ -21,7 +21,7 @@ class VIEW_OT_set_view_axis(bpy.types.Operator):
             self.report({'WARNING'}, "Could not find a 3D Viewport window region")
             return {'CANCELLED'}
 
-        settings = context.scene.cad_tool_settings
+        settings = context.scene.scene_cad_settings
         
         # Use the standard and most robust method for context override.
         with context.temp_override(area=area, region=region):

--- a/properties.py
+++ b/properties.py
@@ -12,7 +12,7 @@ def update_ref_image_property(self, context):
 
 def update_ref_image_visibility(self, context):
     """Toggles the visibility of all reference image empties."""
-    settings = context.scene.cad_tool_settings
+    settings = context.scene.scene_cad_settings
     view_keys = ['top', 'front', 'right', 'bottom', 'back', 'left']
     for view_key in view_keys:
         image_settings = getattr(settings, f"{view_key}_image", None)
@@ -47,7 +47,7 @@ def update_units_and_grid(self, context):
         return
         
     scene = context.scene
-    settings = scene.cad_tool_settings
+    settings = scene.scene_cad_settings
 
     if settings.unit_system == 'METRIC':
         scene.unit_settings.system = 'METRIC'
@@ -96,14 +96,15 @@ class BevelFeature(CADFeature):
     bevel_segments: bpy.props.IntProperty(name="Segments", default=4, min=1)
 
 
-class CADToolsSettings(bpy.types.PropertyGroup):
-    """Stores settings for the CAD addon."""
-    # --- Feature Tree ---
+class ObjectCADSettings(bpy.types.PropertyGroup):
+    """Stores object-specific settings for the CAD addon, primarily the feature tree."""
     feature_tree: bpy.props.CollectionProperty(type=CADFeature)
     active_feature_index: bpy.props.IntProperty()
-
-    # --- UI Expansion States ---
     expand_feature_tree: bpy.props.BoolProperty(default=True)
+
+class SceneCADSettings(bpy.types.PropertyGroup):
+    """Stores scene-level settings for the CAD addon."""
+    # --- UI Expansion States ---
     expand_view_navigator: bpy.props.BoolProperty(default=True)
     expand_reference_sketches: bpy.props.BoolProperty(default=False)
     expand_units_and_grid: bpy.props.BoolProperty(default=False)
@@ -140,15 +141,18 @@ classes = (
     CADFeature,
     ExtrudeFeature,
     BevelFeature,
-    CADToolsSettings,
+    ObjectCADSettings,
+    SceneCADSettings,
 )
 
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
-    bpy.types.Object.cad_tool_settings = bpy.props.PointerProperty(type=CADToolsSettings)
+    bpy.types.Object.object_cad_settings = bpy.props.PointerProperty(type=ObjectCADSettings)
+    bpy.types.Scene.scene_cad_settings = bpy.props.PointerProperty(type=SceneCADSettings)
 
 def unregister():
-    del bpy.types.Object.cad_tool_settings
+    del bpy.types.Scene.scene_cad_settings
+    del bpy.types.Object.object_cad_settings
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)

--- a/ui/draw_handlers.py
+++ b/ui/draw_handlers.py
@@ -30,7 +30,7 @@ def get_view_orientation(context):
 
 def draw_grid_dimensions_callback(context):
     """Draws dimension labels on the grid in the 3D viewport."""
-    settings = context.scene.cad_tool_settings
+    settings = context.scene.scene_cad_settings
     if not settings.show_grid_dimensions:
         return
 

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -48,9 +48,9 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
     bl_region_type = 'UI'
     bl_category = 'CAD Tools'
 
-    def _draw_ref_image_ui(self, layout, settings, view_name, view_type):
+    def _draw_ref_image_ui(self, layout, scene_settings, view_name, view_type):
         """Helper function to draw the UI for a single reference image view."""
-        image_settings = getattr(settings, f"{view_name.lower()}_image")
+        image_settings = getattr(scene_settings, f"{view_name.lower()}_image")
         box = layout.box()
         row = box.row()
         icon = 'IMAGE_DATA' if image_settings.filepath else 'NONE'
@@ -70,14 +70,14 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        settings = context.scene.cad_tool_settings
+        scene_settings = context.scene.scene_cad_settings
         obj = context.object
 
         # --- Feature Tree Section ---
         if obj:
             # Check if the object has our custom property group
-            if hasattr(obj, 'cad_tool_settings'):
-                obj_settings = obj.cad_tool_settings
+            if hasattr(obj, 'object_cad_settings'):
+                obj_settings = obj.object_cad_settings
                 ft_box = layout.box()
                 row = ft_box.row()
                 row.prop(obj_settings, "expand_feature_tree", text="Feature Tree", icon='OUTLINER_DATA_MODIFIER')
@@ -102,8 +102,8 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
         
         # --- View Navigator Section ---
         view_box = layout.box()
-        view_box.prop(settings, "expand_view_navigator", text="View Navigator", icon='VIEW3D')
-        if settings.expand_view_navigator:
+        view_box.prop(scene_settings, "expand_view_navigator", text="View Navigator", icon='VIEW3D')
+        if scene_settings.expand_view_navigator:
             row = view_box.row(align=True)
             row.operator(VIEW_OT_set_view_axis.bl_idname, text="Top").view_type = 'TOP'
             row.operator(VIEW_OT_set_view_axis.bl_idname, text="Front").view_type = 'FRONT'
@@ -115,45 +115,45 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
             row = view_box.row(align=True)
             row.operator(VIEW_OT_set_view_axis.bl_idname, text="Perspective", icon='VIEW_PERSPECTIVE').view_type = 'PERSP'
             col = view_box.column(align=True)
-            col.prop(settings, "pan_x", text="L/R")
-            col.prop(settings, "pan_y", text="U/D")
+            col.prop(scene_settings, "pan_x", text="L/R")
+            col.prop(scene_settings, "pan_y", text="U/D")
 
         # --- Reference Sketches Section ---
         ref_box = layout.box()
-        ref_box.prop(settings, "expand_reference_sketches", text="Reference Sketches", icon='IMAGE')
-        if settings.expand_reference_sketches:
-            ref_box.prop(settings, "show_ref_sketches", text="Show/Hide All", toggle=True)
-            self._draw_ref_image_ui(ref_box, settings, "Top", "TOP")
-            self._draw_ref_image_ui(ref_box, settings, "Front", "FRONT")
-            self._draw_ref_image_ui(ref_box, settings, "Right", "RIGHT")
-            self._draw_ref_image_ui(ref_box, settings, "Bottom", "BOTTOM")
-            self._draw_ref_image_ui(ref_box, settings, "Back", "BACK")
-            self._draw_ref_image_ui(ref_box, settings, "Left", "LEFT")
+        ref_box.prop(scene_settings, "expand_reference_sketches", text="Reference Sketches", icon='IMAGE')
+        if scene_settings.expand_reference_sketches:
+            ref_box.prop(scene_settings, "show_ref_sketches", text="Show/Hide All", toggle=True)
+            self._draw_ref_image_ui(ref_box, scene_settings, "Top", "TOP")
+            self._draw_ref_image_ui(ref_box, scene_settings, "Front", "FRONT")
+            self._draw_ref_image_ui(ref_box, scene_settings, "Right", "RIGHT")
+            self._draw_ref_image_ui(ref_box, scene_settings, "Bottom", "BOTTOM")
+            self._draw_ref_image_ui(ref_box, scene_settings, "Back", "BACK")
+            self._draw_ref_image_ui(ref_box, scene_settings, "Left", "LEFT")
 
         # --- Units & Grid Section ---
         unit_box = layout.box()
-        unit_box.prop(settings, "expand_units_and_grid", text="Units & Grid", icon='GRID')
-        if settings.expand_units_and_grid:
+        unit_box.prop(scene_settings, "expand_units_and_grid", text="Units & Grid", icon='GRID')
+        if scene_settings.expand_units_and_grid:
             row = unit_box.row(align=True)
-            row.prop(settings, "unit_system", expand=True)
-            if settings.unit_system == 'METRIC':
+            row.prop(scene_settings, "unit_system", expand=True)
+            if scene_settings.unit_system == 'METRIC':
                 row = unit_box.row(align=True)
-                row.prop(settings, "metric_unit", expand=True)
+                row.prop(scene_settings, "metric_unit", expand=True)
             row = unit_box.row(align=True)
-            row.prop(settings, "show_grid", text="Show Grid")
-            row.prop(settings, "grid_spacing", text="Spacing")
+            row.prop(scene_settings, "show_grid", text="Show Grid")
+            row.prop(scene_settings, "grid_spacing", text="Spacing")
             unit_box.separator()
-            unit_box.prop(settings, "show_grid_dimensions", text="Show Dimensions")
-            if settings.show_grid_dimensions:
+            unit_box.prop(scene_settings, "show_grid_dimensions", text="Show Dimensions")
+            if scene_settings.show_grid_dimensions:
                 col = unit_box.column(align=True)
                 col.use_property_split = True
-                col.prop(settings, "grid_dimension_font_size", text="Font Size")
-                col.prop(settings, "grid_dimension_color", text="Color")
+                col.prop(scene_settings, "grid_dimension_font_size", text="Font Size")
+                col.prop(scene_settings, "grid_dimension_color", text="Color")
 
         # --- 2D Sketching Section ---
         sketch_box = layout.box()
-        sketch_box.prop(settings, "expand_2d_sketching", text="2D Sketching", icon='GREASEPENCIL')
-        if settings.expand_2d_sketching:
+        sketch_box.prop(scene_settings, "expand_2d_sketching", text="2D Sketching", icon='GREASEPENCIL')
+        if scene_settings.expand_2d_sketching:
             row = sketch_box.row(align=True)
             row.operator(SKETCH_OT_draw_line.bl_idname, text="Line", icon='CURVE_PATH')
             # The following operators are not yet implemented
@@ -164,13 +164,13 @@ class VIEW3D_PT_cad_tools(bpy.types.Panel):
             # row.operator(SKETCH_OT_draw_arc.bl_idname, text="Arc", icon='CURVE_NCIRCLE')
             # row.operator(SKETCH_OT_draw_circle_diameter.bl_idname, text="2P Circle", icon='MESH_CIRCLE')
             col = sketch_box.column(align=True)
-            col.prop(settings, "use_grid_snap")
-            col.prop(settings, "use_vertex_snap")
+            col.prop(scene_settings, "use_grid_snap")
+            col.prop(scene_settings, "use_vertex_snap")
 
         # --- 3D Operations Section ---
         op_box = layout.box()
-        op_box.prop(settings, "expand_3d_operations", text="3D Operations", icon='MODIFIER')
-        if settings.expand_3d_operations:
+        op_box.prop(scene_settings, "expand_3d_operations", text="3D Operations", icon='MODIFIER')
+        if scene_settings.expand_3d_operations:
             op_box.operator(MESH_OT_simple_extrude.bl_idname, text="Extrude", icon='MOD_SOLIDIFY')
             op_box.operator(MESH_OT_inset_faces.bl_idname, text="Inset", icon='FACESEL')
             op_box.operator(MESH_OT_offset_edges.bl_idname, text="Offset", icon='EDGESEL')


### PR DESCRIPTION
This major refactoring addresses a critical stability issue by separating the addon's properties into two distinct groups:

- `SceneCADSettings`: Contains global settings like units, grid, and UI panel states. Registered to `bpy.types.Scene`.
- `ObjectCADSettings`: Contains object-specific data, primarily the feature tree. Registered to `bpy.types.Object`.

This change resolves an `AttributeError` caused by incorrectly accessing scene-level data from an object context. It also creates a much more robust and maintainable architecture for the addon, preventing similar errors in the future. All property accessors throughout the codebase have been updated to reflect this new structure.